### PR TITLE
Baker performance hotfix

### DIFF
--- a/docker-compose.default.yml
+++ b/docker-compose.default.yml
@@ -10,7 +10,7 @@ services:
       - "<host_db_port>:5432"
     volumes:
       - microseil:/var/lib/postgresql/data
-  
+
   web:
     build: .
     tty: true

--- a/server/queries.py
+++ b/server/queries.py
@@ -176,10 +176,10 @@ def endorsements_missed_between(baker, start_cycle, end_cycle):
     start_level = cycle_to_level(start_cycle)
     end_level = cycle_to_level(end_cycle+1) - 1
     rights = endorsing_rights \
-        .query(endorsing_rights.level,
-               endorsing_rights.level.count()) \
+        .query(endorsing_rights.block_level,
+               endorsing_rights.block_level.count()) \
         .filter(endorsing_rights.delegate == baker,
-                endorsing_rights.level.between(start_level, end_level)) \
+                endorsing_rights.block_level.between(start_level, end_level)) \
         .scalar()
 
     if rights is None:

--- a/server/queries.py
+++ b/server/queries.py
@@ -317,7 +317,7 @@ def commitments_made_between(baker, start_cycle, end_cycle):
 
 def all_bakers():
     return bakers.query(bakers.pkh).order_by(bakers.staking_balance.desc()) \
-                                   .limit(1000).vector()
+                                   .limit(MAX_LIMIT).vector()
 
 
 def active_bakers_between(start_cycle, end_cycle):

--- a/server/service_utils.py
+++ b/server/service_utils.py
@@ -97,9 +97,8 @@ def populate_from_cycle(table, after=None):
                         session = get_session()
                         session.add_all(data)
                         session.commit()
-                        session.close()
-                        print("Done")
-                        if (after != None):
+                        session.close()                        
+                        if (after):
                             after(cycle)
                     else:
                         print("No data for cycle %s. Skipping..." % cycle)

--- a/server/service_utils.py
+++ b/server/service_utils.py
@@ -98,6 +98,7 @@ def populate_from_cycle(table, after=None):
                         session.add_all(data)
                         session.commit()
                         session.close()                        
+                        print("done")
                         if (after):
                             after(cycle)
                     else:


### PR DESCRIPTION
Fixes an issue where an old routine for calculating grades causes the script to crash upon receiving an unexpected rpc response. Updated to remove this unnecessary code.